### PR TITLE
feat: add volume controller to sound settings

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -103,6 +103,10 @@
         "selectSound": {
           "label": "Sound",
           "placeholder": "Select a sound"
+        },
+        "volume": {
+          "title": "Volume",
+          "description": "Adjust the volume level for sound effects."
         }
       },
       "notifications": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -103,6 +103,10 @@
         "selectSound": {
           "label": "Sonido",
           "placeholder": "Selecciona un sonido"
+        },
+        "volume": {
+          "title": "Volumen",
+          "description": "Ajusta el nivel de volumen para los efectos de sonido."
         }
       },
       "notifications": {

--- a/package.json
+++ b/package.json
@@ -62,5 +62,6 @@
     "husky": "^9.1.7",
     "prettier": "^3.5.2",
     "typescript": "5.9.3"
-  }
+  },
+  "packageManager": "pnpm@10.28.0+sha512.05df71d1421f21399e053fde567cea34d446fa02c76571441bfc1c7956e98e363088982d940465fd34480d4d90a0668bc12362f8aa88000a64e83d0b0e47be48"
 }

--- a/src/components/Form/SliderInput/index.tsx
+++ b/src/components/Form/SliderInput/index.tsx
@@ -1,0 +1,66 @@
+import { Box, Flex, Slider, Text } from '@chakra-ui/react';
+import React from 'react';
+
+interface Props {
+  onChange: (value: number) => void;
+  title: string;
+  description?: string;
+  value: number;
+  min?: number;
+  max?: number;
+  step?: number;
+  disabled?: boolean;
+}
+
+export const SliderInput = ({
+  onChange,
+  title,
+  description,
+  value,
+  min = 0,
+  max = 1,
+  step = 0.01,
+  disabled = false,
+}: Props) => {
+  const handleChange = (details: { value: number[] }) => {
+    onChange(details.value[0]);
+  };
+
+  const percentage = Math.round(value * 100);
+
+  return (
+    <Flex w='full' direction='column' gap={2} opacity={disabled ? 0.5 : 1}>
+      <Flex justifyContent='space-between' alignItems='center'>
+        <Box>
+          <Text fontWeight={'medium'} textTransform={'capitalize'}>
+            {title}
+          </Text>
+          <Text fontWeight={'light'} color={'gray.400'} fontSize={'xs'}>
+            {description}
+          </Text>
+        </Box>
+        <Text fontWeight={'medium'} fontSize={'sm'} minW={'40px'} textAlign={'right'}>
+          {percentage}%
+        </Text>
+      </Flex>
+      <Slider.Root
+        min={min}
+        max={max}
+        step={step}
+        value={[value]}
+        onValueChange={handleChange}
+        disabled={disabled}
+        width='full'
+      >
+        <Slider.Control>
+          <Slider.Track>
+            <Slider.Range />
+          </Slider.Track>
+          <Slider.Thumb index={0}>
+            <Slider.HiddenInput />
+          </Slider.Thumb>
+        </Slider.Control>
+      </Slider.Root>
+    </Flex>
+  );
+};

--- a/src/components/Pomodoro/Settings/General/components/Sounds/index.tsx
+++ b/src/components/Pomodoro/Settings/General/components/Sounds/index.tsx
@@ -1,13 +1,15 @@
 import { VStack } from '@chakra-ui/react';
 import React from 'react';
 import { SwitchInput } from '@/components/Form/SwitchInput';
+import { SliderInput } from '@/components/Form/SliderInput';
 import { useTranslations } from 'use-intl';
 import { useSettings } from '@/hooks/useSettings';
 import useSettingsStore from '@/stores/Settings.store';
 
 export const Sounds = () => {
-  const { handleSwitchSounds } = useSettings();
+  const { handleSwitchSounds, handleVolumeChange } = useSettings();
   const enableSounds = useSettingsStore((state) => state.enableSounds);
+  const volume = useSettingsStore((state) => state.volume);
   const t = useTranslations('settings.sections.sounds');
 
   return (
@@ -18,6 +20,13 @@ export const Sounds = () => {
         value={enableSounds}
         defaultValue={false}
         onChange={(value: boolean) => handleSwitchSounds(value)}
+      />
+      <SliderInput
+        title={t('volume.title')}
+        description={t('volume.description')}
+        value={volume}
+        onChange={handleVolumeChange}
+        disabled={!enableSounds}
       />
     </VStack>
   );

--- a/src/constants/DefaultSettings.ts
+++ b/src/constants/DefaultSettings.ts
@@ -39,5 +39,6 @@ export const DefaultSettings: Settings = {
   autoOrderTasks: true,
   autoStartNextTask: true,
   enableSounds: true,
+  volume: 0.5,
   enableNotifications: true,
 };

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -25,6 +25,7 @@ export const useSettings = () => {
   const setBreaksInterval = useSettingsStore((state) => state.setBreaksInterval);
 
   const setEnableSounds = useSettingsStore((state) => state.setEnableSounds);
+  const setVolume = useSettingsStore((state) => state.setVolume);
   const setEnableNotifications = useSettingsStore((state) => state.setEnableNotifications);
 
   const handleSwitchSession = (value: boolean) => {
@@ -67,6 +68,10 @@ export const useSettings = () => {
     toastSuccess(t('settingsSaved'));
   };
 
+  const handleVolumeChange = (value: number) => {
+    setVolume(value);
+  };
+
   const handleChangeBreakDuration = (type: SessionStatusEnum, duration: number) => {
     setBreaksDuration({
       ...breaksDuration,
@@ -98,6 +103,7 @@ export const useSettings = () => {
 
   return {
     handleSwitchSounds,
+    handleVolumeChange,
     handleSwitchNotifications,
     handleChangeBreakDuration,
     handleBreaksInterval,

--- a/src/hooks/useSounds.ts
+++ b/src/hooks/useSounds.ts
@@ -3,12 +3,14 @@ import useSettingsStore from '@/stores/Settings.store';
 
 export const useSounds = () => {
   const enableSounds = useSettingsStore((state) => state.enableSounds);
+  const volume = useSettingsStore((state) => state.volume);
 
   const playSound = (): void => {
     if (!enableSounds) return;
 
     const sound = new Howl({
       src: ['sounds/play.wav'],
+      volume,
     });
 
     sound.play();
@@ -19,6 +21,7 @@ export const useSounds = () => {
 
     const sound = new Howl({
       src: ['sounds/resume.wav'],
+      volume,
     });
 
     sound.play();
@@ -29,6 +32,7 @@ export const useSounds = () => {
 
     const sound = new Howl({
       src: ['sounds/radio.mp3'],
+      volume,
     });
 
     sound.play();

--- a/src/interfaces/Settings.interface.ts
+++ b/src/interfaces/Settings.interface.ts
@@ -19,5 +19,6 @@ export interface Settings {
   autoOrderTasks: boolean;
   autoStartNextTask: boolean;
   enableSounds: boolean;
+  volume: number;
   enableNotifications: boolean;
 }

--- a/src/stores/Settings.store.ts
+++ b/src/stores/Settings.store.ts
@@ -19,6 +19,7 @@ interface SettingsActions {
   setAutoStartNextTask: (autoStartNextTask: boolean) => void;
   setIsLongBreakPerTask: (longBreakPerTask: boolean) => void;
   setEnableSounds: (enableSounds: boolean) => void;
+  setVolume: (volume: number) => void;
   setEnableNotifications: (enableNotifications: boolean) => void;
 }
 
@@ -37,8 +38,10 @@ const useSettingsStore = create<Settings & SettingsActions>()(
         autoStartNextTask: DefaultSettings.autoStartNextTask,
         isLongBreakPerTask: DefaultSettings.isLongBreakPerTask,
         enableSounds: DefaultSettings.enableSounds,
+        volume: DefaultSettings.volume,
         enableNotifications: DefaultSettings.enableNotifications,
         setEnableSounds: (enableSounds) => set(() => ({ enableSounds })),
+        setVolume: (volume) => set(() => ({ volume })),
         setEnableNotifications: (enableNotifications) => set(() => ({ enableNotifications })),
         setLocale: (locale) => set(() => ({ locale })),
         setIsLongBreakPerTask: (longBreakPerTask) =>


### PR DESCRIPTION
## Description

Adds a volume controller slider to the Sound settings, allowing users to adjust the volume level (0-100%) for all sound effects in the app.

## What Changed?

- **New `SliderInput` component** (`src/components/Form/SliderInput/index.tsx`): A reusable slider form input with percentage display, min/max/step support, and disabled state
- **`Settings` interface**: Added `volume: number` property
- **`DefaultSettings`**: Default volume set to `0.5` (50%)
- **`Settings.store`**: Added `volume` state and `setVolume` action, persisted to localStorage
- **`useSettings` hook**: Added `handleVolumeChange` handler and wired up `setVolume`
- **`useSounds` hook**: Reads `volume` from the store and passes it to every `Howl` instance (`playSound`, `resumeSound`, `radioSound`)
- **Sounds settings UI**: Added volume slider below the "Enable Sound" toggle; slider is disabled when sounds are off
- **i18n translations**: Added `volume.title` and `volume.description` in both English and Spanish

### No dependencies added/removed

Closes #20