### PR TITLE
fix: prevent negative numbers in long break interval input

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -588,7 +588,6 @@ Ensure your changes are accessible:
   ```
 
 - 🚨 **Report vulnerabilities privately**:
-
   - See [SECURITY.md](SECURITY.md) for reporting process
   - Do NOT open public issues for security bugs
 
@@ -1282,7 +1281,6 @@ Asegura que tus cambios sean accesibles:
   ```
 
 - 🚨 **Reporta vulnerabilidades privadamente**:
-
   - Ver [SECURITY.md](SECURITY.md) para el proceso de reporte
   - NO abras issues públicos para bugs de seguridad
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -133,7 +133,8 @@
         },
         "longBreakInterval": {
           "title": "Long Break Interval",
-          "description": "How many completed pomodoros to go long break."
+          "description": "How many completed pomodoros to go long break.",
+          "error": "The interval must be at least 1."
         }
       },
       "tasks": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -134,7 +134,8 @@
         },
         "longBreakInterval": {
           "title": "Intervalo de descanso largo",
-          "description": "Cuántas sesiones de trabajo antes de un descanso largo."
+          "description": "Cuántas sesiones de trabajo antes de un descanso largo.",
+          "error": "El intervalo debe ser al menos 1."
         }
       },
       "tasks": {

--- a/src/components/Pomodoro/Settings/General/components/Session/index.tsx
+++ b/src/components/Pomodoro/Settings/General/components/Session/index.tsx
@@ -23,6 +23,7 @@ export const Session = () => {
   const debouncedBreaksInterval = useDebounce(handleBreaksInterval, 1000);
 
   const handleBreaksIntervalChange = (value: number) => {
+    if (value < 1) return;
     setLocalBreaksInterval(value);
     debouncedBreaksInterval(value);
   };
@@ -61,6 +62,7 @@ export const Session = () => {
           onValueChange={(e) => handleBreaksIntervalChange(Number(e.value))}
           unstyled
           spinOnPress={false}
+          min={1}
         >
           <HStack gap='2'>
             <NumberInput.DecrementTrigger asChild>

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -1,14 +1,14 @@
+import { SCUDERIAS } from '@/constants/Scuderias';
+import { SessionStatusEnum } from '@/enums/SessionStatus.enum';
+import { TireTypeEnum } from '@/enums/TireType.enum';
+import { useAlert } from '@/hooks/useAlert';
 import { Team } from '@/interfaces/Teams.interface';
 import usePomodoroStore from '@/stores/Pomodoro.store';
 import useSettingsStore from '@/stores/Settings.store';
-import { TireTypeEnum } from '@/enums/TireType.enum';
-import { SessionStatusEnum } from '@/enums/SessionStatus.enum';
-import { SCUDERIAS } from '@/constants/Scuderias';
-import { useAlert } from '@/hooks/useAlert';
 import { useTranslations } from 'use-intl';
 
 export const useSettings = () => {
-  const { toastSuccess } = useAlert();
+  const { toastSuccess, toastError } = useAlert();
   const t = useTranslations('settings');
 
   const tiresSettings = useSettingsStore((state) => state.tiresSettings);
@@ -54,6 +54,10 @@ export const useSettings = () => {
   };
 
   const handleBreaksInterval = (value: number) => {
+    if (value < 1) {
+      toastError(t('sections.session.longBreakInterval.error'));
+      return;
+    }
     setBreaksInterval(value);
     toastSuccess(t('settingsSaved'));
   };


### PR DESCRIPTION
Description

This PR prevents users from entering negative values when editing the Pomodoro interval count for the long break setting. Previously, negative numbers could be entered, which could lead to invalid timer configurations and unexpected behavior.
This update improves input validation and ensures data integrity in timer settings.

What Changed?

Added input validation to block negative values in the long break interval field

Applied a minimum value constraint to prevent invalid configurations

Ensured the timer configuration remains stable and consistent

Improved overall robustness of user input handling

<img width="810" height="108" alt="image" src="https://github.com/user-attachments/assets/aa0cfc40-8cef-4632-a1fc-54a61ca385aa" />


No dependencies added/removed

Closes #23 