### PR TITLE
feat(pomodoro): add current timer to browser tab

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -78,6 +78,7 @@
     "longBreakLabel": "Long Break",
     "boxTitle": "Box, Box!",
     "boxDescription": "Time to break",
+    "pausedTitle": "Paused",
     "interruptAccept": "Are you sure you want to interrupt the session?",
     "tasks": {
       "title": "Plan your strategy",

--- a/messages/es.json
+++ b/messages/es.json
@@ -79,6 +79,7 @@
     "longBreakLabel": "Descanso largo",
     "boxTitle": "Box, Box!",
     "boxDescription": "Hora de tomar un descanso.",
+    "pausedTitle": "En pausa",
     "interruptAccept": "¿Deseas interrumpir la sesión actual?",
     "tasks": {
       "title": "Planifica tu estrategia",

--- a/src/components/Pomodoro/Counter/index.tsx
+++ b/src/components/Pomodoro/Counter/index.tsx
@@ -22,6 +22,7 @@ import _ from 'lodash';
 import { useTaskStore } from '@/stores/Tasks.store';
 import { useTasks } from '@/hooks/useTasks';
 import { usePomodoroStore } from '@/stores/Pomodoro.store';
+import { formatMs } from '@/utils/formatMs.utils';
 
 export const Counter = () => {
   const status = useSessionStore((state) => state.status);
@@ -83,6 +84,8 @@ export const Counter = () => {
   const handleTick = ({ total }: { total: number }) => {
     const isRunning = countdownRef.current?.isStarted() && !countdownRef.current?.isPaused();
     if (!isRunning) return;
+
+    document.title = `${formatMs(total)} - ${t(status === SessionStatusEnum.IN_SESSION ? 'sessionLabel' : status === SessionStatusEnum.SHORT_BREAK ? 'shortBreakLabel' : 'longBreakLabel')}`;
 
     if (total <= 4000 && !isEndingSoon) {
       setIsEndingSoon(true);

--- a/src/hooks/usePomodoro.ts
+++ b/src/hooks/usePomodoro.ts
@@ -161,6 +161,8 @@ export const usePomodoro = () => {
   };
 
   const pause = async () => {
+    document.title = `Pitmydoro - ${t('pausedTitle')}`;
+
     setIsActive(false);
     setStopped(true);
 
@@ -255,6 +257,8 @@ export const usePomodoro = () => {
   };
 
   const complete = async () => {
+    document.title = `${t('boxTitle')}`;
+
     setIsActive(false);
     setStopped(true);
 
@@ -356,6 +360,8 @@ export const usePomodoro = () => {
   };
 
   const reset = (newTire?: TireTypeEnum | null, showRedFlag = false) => {
+    document.title = `Pitmydoro - ${t('pausedTitle')}`;
+
     if (showRedFlag || currentPomodoro?.status === 'running') setFlag(FlagEnum.RED);
     setStopped(true);
 

--- a/src/utils/formatMs.utils.ts
+++ b/src/utils/formatMs.utils.ts
@@ -1,0 +1,14 @@
+export const formatMs = (ms: number): string => {
+  const h = Math.floor(ms / 3600000);
+  const m = Math.floor((ms % 3600000) / 60000);
+  const s = Math.floor((ms % 60000) / 1000);
+
+  const mm = m.toString().padStart(2, '0');
+  const ss = s.toString().padStart(2, '0');
+
+  if (h > 0) {
+    return `${h.toString().padStart(2, '0')}:${mm}:${ss}`;
+  }
+
+  return `${mm}:${ss}`;
+};

--- a/tests/pomodoro.spec.ts
+++ b/tests/pomodoro.spec.ts
@@ -94,8 +94,13 @@ test.describe('Pomodoro', () => {
     await expect(timer).toContainText('25:00');
 
     await page.getByRole('button', { name: 'Start' }).click();
-    await page.waitForTimeout(10000);
+
+    await page.waitForTimeout(5000);
+    await expect(page).toHaveTitle(/24:5/);
+    await page.waitForTimeout(5000);
+
     await page.getByRole('button', { name: 'Pause' }).click();
+    await expect(page).not.toHaveTitle(/24:5/);
 
     await expect(timer).toContainText('24:50');
     await expect(page.getByTestId('flag-yellow')).toBeVisible();
@@ -111,5 +116,7 @@ test.describe('Pomodoro', () => {
     await expect(timer).toContainText('25:00');
     await expect(page.getByTestId('flag-red')).toBeVisible();
     await expect(page.getByTestId('flag-yellow')).not.toBeVisible();
+
+    await expect(page).not.toHaveTitle(/25:00/);
   });
 });


### PR DESCRIPTION
## Description
Displays the current timer countdown in the browser tab title, allowing users to monitor timer progress without switching to the app tab.

## What Changed?
- Implemented dynamic browser tab title updates with current timer value
- Added proper timer formatting for tab title display (e.g., "25:00 - Session")
- Ensured tab title updates in real-time as timer counts down

## Screenshots / Videos
<img width="230" height="52" alt="image" src="https://github.com/user-attachments/assets/13e09b58-f589-4af4-9da9-dd1989ea7baa" />
<img width="230" height="52" alt="image" src="https://github.com/user-attachments/assets/0d83c304-5ce5-427d-a295-0cca19f4a685" />
<img width="230" height="52" alt="image" src="https://github.com/user-attachments/assets/3d38e4ac-0743-446f-8524-8c2254e002b6" />
<img width="230" height="52" alt="image" src="https://github.com/user-attachments/assets/2671f01b-e858-4a4d-8073-cba6e18adada" />


## Related Issues
Closes #39 