### PR TITLE
feat(settings): configure early alert timing

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -326,6 +326,13 @@
         "enableNotifications": {
           "title": "Enable Notifications",
           "description": "Enable or disable notifications."
+        },
+        "earlyAlert": {
+          "title": "Early alert",
+          "description": "Alert this many seconds before the timer ends.",
+          "decrease": "Decrease early alert time",
+          "increase": "Increase early alert time",
+          "error": "Early alert time must be between 1 and 60 seconds."
         }
       },
       "language": {

--- a/messages/es.json
+++ b/messages/es.json
@@ -327,6 +327,13 @@
         "enableNotifications": {
           "title": "Habilitar notificaciones",
           "description": "Habilitar o deshabilitar las notificaciones."
+        },
+        "earlyAlert": {
+          "title": "Aviso anticipado",
+          "description": "Avisa esta cantidad de segundos antes de que termine el temporizador.",
+          "decrease": "Reducir el tiempo de aviso anticipado",
+          "increase": "Aumentar el tiempo de aviso anticipado",
+          "error": "El aviso anticipado debe estar entre 1 y 60 segundos."
         }
       },
       "language": {

--- a/src/components/Pomodoro/Counter/index.tsx
+++ b/src/components/Pomodoro/Counter/index.tsx
@@ -52,6 +52,7 @@ export const Counter = () => {
   const tasks = useTaskStore((state) => state.tasks);
   const tiresSettings = useSettingsStore((state) => state.tiresSettings);
   const enableNotifications = useSettingsStore((state) => state.enableNotifications);
+  const earlyAlertSeconds = useSettingsStore((state) => state.earlyAlertSeconds);
   const breaksDuration = useSettingsStore((state) => state.breaksDuration);
   const mode = useSettingsStore((state) => state.mode);
   const minimalSessionDuration = useSettingsStore((state) => state.minimalSessionDuration);
@@ -101,7 +102,8 @@ export const Counter = () => {
 
     document.title = `${formatSeconds(Math.floor(total / 1000), 'clock')} - ${pomodoroT(status === SessionStatusEnum.IN_SESSION ? 'sessionLabel' : status === SessionStatusEnum.SHORT_BREAK ? 'shortBreakLabel' : 'longBreakLabel')}`;
 
-    if (total <= 4000 && !isEndingSoon) {
+    const earlyAlertThreshold = earlyAlertSeconds * 1000;
+    if (total <= earlyAlertThreshold && !isEndingSoon) {
       setIsEndingSoon(true);
       radioSound();
       if (isDesktopDevice()) {
@@ -119,7 +121,7 @@ export const Counter = () => {
       }
     }
 
-    if (total > 4000 && isEndingSoon) {
+    if (total > earlyAlertThreshold && isEndingSoon) {
       setIsEndingSoon(false);
     }
   };

--- a/src/components/Pomodoro/Settings/General/components/Notifcations/index.tsx
+++ b/src/components/Pomodoro/Settings/General/components/Notifcations/index.tsx
@@ -1,13 +1,15 @@
-import { VStack } from '@chakra-ui/react';
+import { Box, Flex, HStack, IconButton, NumberInput, Text, VStack } from '@chakra-ui/react';
 import { SwitchInput } from '@/components/Form/SwitchInput';
 import React from 'react';
 import { useTranslations } from 'next-intl';
 import { useSettings } from '@/hooks/useSettings';
 import useSettingsStore from '@/stores/Settings.store';
+import { LuMinus, LuPlus } from 'react-icons/lu';
 
 export const Notifications = () => {
-  const { handleSwitchNotifications } = useSettings();
+  const { handleSwitchNotifications, handleEarlyAlertSeconds } = useSettings();
   const enableNotifications = useSettingsStore((state) => state.enableNotifications);
+  const earlyAlertSeconds = useSettingsStore((state) => state.earlyAlertSeconds);
   const t = useTranslations('settings.sections.notifications');
 
   return (
@@ -19,6 +21,38 @@ export const Notifications = () => {
         defaultValue={false}
         onChange={(value: boolean) => handleSwitchNotifications(value)}
       />
+      <Flex w='full' justifyContent='space-between' alignItems='center' gap={4}>
+        <Box>
+          <Text fontWeight={'medium'}>{t('earlyAlert.title')}</Text>
+          <Text fontWeight={'light'} color={'gray.400'} fontSize={'xs'}>
+            {t('earlyAlert.description')}
+          </Text>
+        </Box>
+        <NumberInput.Root
+          aria-label={t('earlyAlert.title')}
+          size={'xs'}
+          value={String(earlyAlertSeconds)}
+          onValueChange={(event) => handleEarlyAlertSeconds(Number(event.value))}
+          unstyled
+          spinOnPress={false}
+          min={1}
+          max={60}
+        >
+          <HStack gap='2'>
+            <NumberInput.DecrementTrigger asChild>
+              <IconButton variant='outline' size='xs' aria-label={t('earlyAlert.decrease')}>
+                <LuMinus />
+              </IconButton>
+            </NumberInput.DecrementTrigger>
+            <NumberInput.ValueText textAlign='center' fontSize='md' minW='3ch' />
+            <NumberInput.IncrementTrigger asChild>
+              <IconButton variant='outline' size='xs' aria-label={t('earlyAlert.increase')}>
+                <LuPlus />
+              </IconButton>
+            </NumberInput.IncrementTrigger>
+          </HStack>
+        </NumberInput.Root>
+      </Flex>
     </VStack>
   );
 };

--- a/src/constants/DefaultSettings.ts
+++ b/src/constants/DefaultSettings.ts
@@ -44,6 +44,7 @@ export const DefaultSettings: Settings = {
   enableSounds: true,
   volume: 1,
   enableNotifications: true,
+  earlyAlertSeconds: 4,
   minimalSessionDuration: 25,
 };
 

--- a/src/hooks/useSettings.ts
+++ b/src/hooks/useSettings.ts
@@ -34,6 +34,7 @@ export const useSettings = () => {
     setSettings,
     setPomodoroMode,
     setEnableNotifications,
+    setEarlyAlertSeconds,
     setMinimalSessionDuration,
   } = useSettingsStore();
 
@@ -92,6 +93,17 @@ export const useSettings = () => {
   const handleSwitchNotifications = async (value: boolean) => {
     setEnableNotifications(value);
     if (user) await userService.updatePreferences(user.uid, { enableNotifications: value });
+    toastSuccess(t('settingsSaved'));
+  };
+
+  const handleEarlyAlertSeconds = async (seconds: number) => {
+    if (!Number.isInteger(seconds) || seconds < 1 || seconds > 60) {
+      toastError(t('sections.notifications.earlyAlert.error'));
+      return;
+    }
+
+    setEarlyAlertSeconds(seconds);
+    if (user) await userService.updatePreferences(user.uid, { earlyAlertSeconds: seconds });
     toastSuccess(t('settingsSaved'));
   };
 
@@ -176,6 +188,7 @@ export const useSettings = () => {
     resetSettings,
     handleVolumeChange,
     handleSwitchNotifications,
+    handleEarlyAlertSeconds,
     handleChangeBreakDuration,
     handleBreaksInterval,
     handleSwitchOrderTasks,

--- a/src/interfaces/Settings.interface.ts
+++ b/src/interfaces/Settings.interface.ts
@@ -28,6 +28,7 @@ export interface Settings {
   enableSounds: boolean;
   volume: number;
   enableNotifications: boolean;
+  earlyAlertSeconds: number;
   mode: PomodoroMode;
   minimalSessionDuration: number;
 }

--- a/src/stores/Settings.store.ts
+++ b/src/stores/Settings.store.ts
@@ -24,6 +24,7 @@ interface SettingsActions {
   setEnableSounds: (enableSounds: boolean) => void;
   setVolume: (volume: number) => void;
   setEnableNotifications: (enableNotifications: boolean) => void;
+  setEarlyAlertSeconds: (seconds: number) => void;
   setMinimalSessionDuration: (duration: number) => void;
   setSettings: (settings: Partial<Settings>) => void;
 }
@@ -46,6 +47,7 @@ const useSettingsStore = create<Settings & SettingsActions>()(
         enableSounds: DefaultSettings.enableSounds,
         volume: DefaultSettings.volume,
         enableNotifications: DefaultSettings.enableNotifications,
+        earlyAlertSeconds: DefaultSettings.earlyAlertSeconds,
         currentScuderia: DefaultSettings.currentScuderia,
         minimalSessionDuration: DefaultSettings.minimalSessionDuration,
         setPomodoroMode: (mode) => set(() => ({ mode })),
@@ -54,6 +56,7 @@ const useSettingsStore = create<Settings & SettingsActions>()(
         setEnableSounds: (enableSounds) => set(() => ({ enableSounds })),
         setVolume: (volume) => set(() => ({ volume })),
         setEnableNotifications: (enableNotifications) => set(() => ({ enableNotifications })),
+        setEarlyAlertSeconds: (earlyAlertSeconds) => set(() => ({ earlyAlertSeconds })),
         setLocale: (locale) => set(() => ({ locale })),
         setIsLongBreakPerTask: (longBreakPerTask) =>
           set(() => ({ isLongBreakPerTask: longBreakPerTask })),


### PR DESCRIPTION
## Summary

- add a 1–60 second early-alert setting, defaulting to the existing 4 seconds
- persist the setting for signed-in users
- use the configured threshold for sound and desktop notifications
- add English and Spanish labels

## Testing

- changed-file ESLint check (0 errors)
- `pnpm format:check`
- `pnpm build` reaches type-checking, then stops on the existing missing `@dnd-kit/utilities` dependency in `SortableItem`

Closes #69
